### PR TITLE
Fix missing Material style

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.material.icons.extended)
+    implementation(libs.google.material)
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
     kapt("androidx.room:room-compiler:2.6.1")

--- a/app/src/main/java/com/example/uniflow/MainActivity.kt
+++ b/app/src/main/java/com/example/uniflow/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -214,6 +215,11 @@ fun FunctionalCalendar(taskList: List<Task>, onDateSelected: (LocalDate) -> Unit
             items((1..daysInMonth).toList()) { day ->
                 val date = currentMonth.atDay(day)
                 val color = markedDates[date] ?: Color.Transparent
+                val textColor = if (color != Color.Transparent) {
+                    if (color.luminance() > 0.5f) Color.Black else Color.White
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                }
 
                 Box(
                     modifier = Modifier
@@ -224,8 +230,10 @@ fun FunctionalCalendar(taskList: List<Task>, onDateSelected: (LocalDate) -> Unit
                         .clickable { onDateSelected(date) },
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(text = day.toString(),
-                        color = if (color != Color.Transparent) Color.White else Color.Unspecified)
+                    Text(
+                        text = day.toString(),
+                        color = textColor
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/uniflow/TasksActivity.kt
+++ b/app/src/main/java/com/example/uniflow/TasksActivity.kt
@@ -10,12 +10,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import com.example.uniflow.data.TaskRepository
 import com.example.uniflow.ui.theme.UniFlowTheme
 import java.time.format.DateTimeFormatter
 
 class TasksActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val repo = TaskRepository.get(this)
@@ -28,6 +30,11 @@ class TasksActivity : ComponentActivity() {
                 }) { padding ->
                     Column(modifier = Modifier.padding(padding).padding(16.dp)) {
                         tasks.forEach { task ->
+                            val textColor = if (task.boja.luminance() > 0.8f) {
+                                MaterialTheme.colorScheme.onSurface
+                            } else {
+                                task.boja
+                            }
                             Text(
                                 "${task.vrsta}: ${task.naziv} - " +
                                         task.datum.format(DateTimeFormatter.ofPattern("dd.MM.yyyy")),
@@ -35,7 +42,7 @@ class TasksActivity : ComponentActivity() {
                                     .fillMaxWidth()
                                     .padding(vertical = 8.dp)
                                     .clickable { /* future details */ },
-                                color = task.boja
+                                color = textColor
                             )
                             Divider()
                         }

--- a/app/src/main/java/com/example/uniflow/data/TaskRepository.kt
+++ b/app/src/main/java/com/example/uniflow/data/TaskRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.map
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import com.example.uniflow.Task
 
 class TaskRepository private constructor(private val dao: TaskDao) {
 

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <style name="Theme.UniFlow" parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ composeBom = "2024.09.00"
 materialIconsExtended = "1.7.8"
 junitJunit = "4.12"
 uiTestJunit4Android = "1.8.2"
+material = "1.11.0"
 
 
 [libraries]
@@ -35,6 +36,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 junit-junit = { group = "junit", name = "junit", version.ref = "junitJunit" }
 androidx-ui-test-junit4-android = { group = "androidx.compose.ui", name = "ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
+google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- include Google Material dependency so Theme.Material3 styles resolve
- ensure day text and task text remain legible against background colors

## Testing
- `./gradlew assembleDebug` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685afb98f9708327b2b910388c854df4